### PR TITLE
Protobuf version error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     ],
     extras_require=extras_deps,
     install_requires=[
+        "protobuf==3.19.0",
         "pysc2>=3.0.0",
         "s2clientprotocol>=4.10.1.75800.0",
         "absl-py>=0.1.0",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ],
     extras_require=extras_deps,
     install_requires=[
-        "protobuf==3.19.0",
+        "protobuf==3.19.5",
         "pysc2>=3.0.0",
         "s2clientprotocol>=4.10.1.75800.0",
         "absl-py>=0.1.0",


### PR DESCRIPTION
```
File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/smac/env/__init__.py", line 6, in <module>
    from smac.env.starcraft2.starcraft2 import StarCraft2Env
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/smac/env/starcraft2/starcraft2.py", line 21, in <module>
    from pysc2 import run_configs
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/pysc2/run_configs/__init__.py", line 18, in <module>
    from pysc2.lib import sc_process
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/pysc2/lib/sc_process.py", line 27, in <module>
    from pysc2.lib import remote_controller
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/pysc2/lib/remote_controller.py", line 24, in <module>
    from pysc2.lib import protocol
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/pysc2/lib/protocol.py", line 29, in <module>
    from s2clientprotocol import sc2api_pb2 as sc_pb
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/s2clientprotocol/sc2api_pb2.py", line 17, in <module>
    from s2clientprotocol import common_pb2 as s2clientprotocol_dot_common__pb2
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/s2clientprotocol/common_pb2.py", line 32, in <module>
    _descriptor.EnumValueDescriptor(
  File "/private/home/samvelyan/anaconda3/envs/composer/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```